### PR TITLE
improved error message when failing to switch to new profile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "collections",
   "description": "Allows creation of installation of mod packs (meta mods that install a bunch of other mods)",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "main": "./out/index.js",
   "license": "GPL-3.0",
   "author": "Black Tree Gaming Ltd.",

--- a/src/index.ts
+++ b/src/index.ts
@@ -585,11 +585,11 @@ function register(context: types.IExtensionContext,
 
   const onSwitchProfile = (profileId: string) => {
     return new Promise<void>((resolve, reject) => {
-      context.api.events.once('profile-did-change', newProfileId => {
+      context.api.events.once('profile-did-change', (newProfileId: string) => {
         if (newProfileId === profileId) {
           resolve();
         } else {
-          reject(new Error('Failed to switch to profile'));
+          reject(new Error(`Failed to switch to profile ${profileId}; got ${newProfileId}`));
         }
       });
       context.api.store.dispatch(actions.setNextProfile(profileId));


### PR DESCRIPTION
This is potentially down to some typing weirdness but there's no real way for us to identify why the profile change failed with the current error message.

Not marking the issue as resolved yet as this commit will simply give us a better idea what went wrong.

nexus-mods/vortex#15326