### PR TITLE
improved error handling when displaying instructions

### DIFF
--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -152,3 +152,9 @@ export async function walkPath(dirPath: string, walkOptions?: IWalkOptions): Pro
     return resolve(walkResults);
   });
 }
+
+export function isEmpty(value: any) {
+  return (!value)
+    || (value.hasOwnProperty('length') && value.length === 0)
+    || (value.constructor === Object && Object.keys(value).length === 0);
+}

--- a/src/views/CollectionPageView/CollectionInstructions.tsx
+++ b/src/views/CollectionPageView/CollectionInstructions.tsx
@@ -4,6 +4,8 @@ import { types, util } from 'vortex-api';
 import { DEFAULT_INSTRUCTIONS } from '../../constants';
 import * as ReactMarkdown from 'react-markdown';
 
+import { isEmpty } from '../../util/util';
+
 export interface IInstructionsProps {
   t: types.TFunction;
   collection: types.IMod;
@@ -23,7 +25,7 @@ function Instructions(props: IInstructionsProps) {
   
   const { required, optional } = React.useMemo(() => {
     return (collection.rules ?? []).reduce((prev, rule) => {
-      if ((rule.extra?.instructions === undefined)
+      if ((isEmpty(rule.extra?.instructions))
           || !['requires', 'recommends'].includes(rule.type)) {
         return prev;
       }


### PR DESCRIPTION
It is possible for an empty string to be set as an instruction - the previous error handling code would wrongfully attempt to render the instruction.

fixes nexus-mods/vortex#14570