### PR TITLE
Allow collection instructions panel to be resized vertically

### DIFF
--- a/style.scss
+++ b/style.scss
@@ -1798,8 +1798,7 @@ ul.collection-mods-page-attrib-tooltip {
 }
 
 #collection-instructions-area {
-  //height: 100%;
-  resize: none;
+  resize: vertical;
 }
 
 .collection-instructions-buttons {


### PR DESCRIPTION
Users can only see 8 lines of these instructions, so this lets them use a drag handle to fill the available space. Note: The panel will not scroll properly if the text box becomes larger than the window and pushes the save button off screen.