### PR TITLE
workshop collections are no longer memoized

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "collections",
   "description": "Allows creation of installation of mod packs (meta mods that install a bunch of other mods)",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "main": "./out/index.js",
   "license": "GPL-3.0",
   "author": "Black Tree Gaming Ltd.",

--- a/src/collectionCreate.ts
+++ b/src/collectionCreate.ts
@@ -1,4 +1,3 @@
-import memoizeOne from 'memoize-one';
 import { MOD_TYPE } from './constants';
 import { createCollectionFromProfile } from './util/transformCollection';
 
@@ -32,13 +31,13 @@ export async function initFromProfile(api: types.IExtensionApi, profileId: strin
   }
 }
 
-const collections = memoizeOne((mods: { [modId: string]: types.IMod }) => {
+const collections = (mods: { [modId: string]: types.IMod }) => {
   const isWorkshopCollection = mod => (mod.type === MOD_TYPE)
           && (mod.attributes?.editable === true);
   return Object.values(mods)
     .filter(isWorkshopCollection)
     .map(coll => new Set((coll.rules ?? []).map(rule => rule.reference.id)));
-});
+};
 
 export function addCollectionCondition(api: types.IExtensionApi, instanceIds: string[]) {
   const state = api.getState();

--- a/src/util/InstallDriver.ts
+++ b/src/util/InstallDriver.ts
@@ -14,8 +14,6 @@ import InfoCache from './InfoCache';
 import { calculateCollectionSize, getUnfulfilledNotificationId, isRelevant, modRuleId, walkPath } from './util';
 
 import * as _ from 'lodash';
-import turbowalk, { IEntry } from 'turbowalk';
-import { IFileListItem, IModReference } from 'vortex-api/lib/extensions/mod_management/types/IMod';
 
 export type Step = 'prepare' | 'changelog' | 'query' | 'start' | 'disclaimer' | 'installing' | 'recommendations' | 'review';
 


### PR DESCRIPTION
- Fixes invalid data being exported as part of a collection.
- Editing collections will unfortunately be slower as a result, but we can't allow for invalid metadata to be exported as part of a collection.

part of nexus-mods/vortex#15703