### PR TITLE
fixed collapsed mods tab table

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "collections",
   "description": "Allows creation of installation of mod packs (meta mods that install a bunch of other mods)",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "main": "./out/index.js",
   "license": "GPL-3.0",
   "author": "Black Tree Gaming Ltd.",

--- a/src/views/CollectionPageView/CollectionOverview.tsx
+++ b/src/views/CollectionPageView/CollectionOverview.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import CollectionReleaseStatus from '../CollectionReleaseStatus';
 import CollectionThumbnail from '../CollectionTile';
 


### PR DESCRIPTION
- This will only happen for large collections where 1 or more mods contain non-semantic versions which the version table attribute is unable to coerce
- Now using the semantic versioning coercion utility function we developed for mod comparisons.