### PR TITLE
fixed crash when cloning an empty collection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "collections",
   "description": "Allows creation of installation of mod packs (meta mods that install a bunch of other mods)",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "main": "./out/index.js",
   "license": "GPL-3.0",
   "author": "Black Tree Gaming Ltd.",

--- a/src/util/transformCollection.ts
+++ b/src/util/transformCollection.ts
@@ -717,7 +717,7 @@ function deduceCollectionAttributes(collectionMod: types.IMod,
     saveEdits: {},
   };
 
-  collectionMod.rules.forEach(rule => {
+  (collectionMod.rules ?? []).forEach(rule => {
     const mod = util.findModByRef(rule.reference, mods);
     if (mod === undefined) {
       // allowing mods to be missing, prior to r32 this would throw an exception


### PR DESCRIPTION
We allow the users to proceed with collection cloning even when none of the collection mods are installed - this can result in an empty collection (rules-wise)

fixes nexus-mods/vortex#17149