### PR TITLE
fixed invalid event handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "collections",
   "description": "Allows creation of installation of mod packs (meta mods that install a bunch of other mods)",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "main": "./out/index.js",
   "license": "GPL-3.0",
   "author": "Black Tree Gaming Ltd.",

--- a/src/util/InstallDriver.ts
+++ b/src/util/InstallDriver.ts
@@ -293,7 +293,7 @@ class InstallDriver {
   }
 
   public installRecommended() {
-    this.mApi.events.emit('install-from-dependencies',
+    this.mApi.emitAndAwait('install-from-dependencies',
                            this.mCollection.id, this.mCollection.rules, true);
     this.mStep = 'recommendations';
     this.triggerUpdate();


### PR DESCRIPTION
Although sync events should still be picked up by the async event handlers - for some reason it messes up on some user environments

fixes nexus-mods/vortex#17315