### PR TITLE
added checksum tests when exporting a collection with replicate

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "collections",
   "description": "Allows creation of installation of mod packs (meta mods that install a bunch of other mods)",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "main": "./out/index.js",
   "license": "GPL-3.0",
   "author": "Black Tree Gaming Ltd.",

--- a/src/util/checksumMatcher.ts
+++ b/src/util/checksumMatcher.ts
@@ -1,0 +1,91 @@
+import * as Bluebird from 'bluebird';
+import * as crc32 from 'crc-32';
+import * as path from 'path';
+import { fs, log, selectors, types, util } from 'vortex-api';
+
+import { ReplicateHashMismatchError } from '../util/errors';
+
+function crcFromBuf(data: Buffer) {
+  // >>> 0 converts signed to unsigned
+  return (crc32.buf(data) >>> 0).toString(16).toUpperCase().padStart(8, '0');
+}
+
+const queue = util.makeQueue();
+
+export function matchChecksums(api: types.IExtensionApi,
+                               gameId: string,
+                               modId: string): Bluebird<void> {
+  const state = api.getState();
+  const mod = state.persistent.mods[gameId][modId];
+  if (!mod?.archiveId) {
+    throw new util.ProcessCanceled('Mod not found');
+  }
+
+  const stagingPath = selectors.installPathForGame(state, gameId);
+
+  const localPath = path.join(stagingPath, mod.installationPath);
+  const archive = state.persistent.downloads.files[mod.archiveId!];
+
+  if (archive === undefined) {
+    throw new util.ProcessCanceled('Archive not found');
+  }
+
+  const choices = mod.attributes?.installerChoices;
+  return queue(() => new Bluebird<void>((resolve, reject) => {
+    api.events.emit('simulate-installer', gameId, mod.archiveId, { choices },
+      async (instRes: types.IInstallResult, tempPath: string) => {
+        try {
+          const dlPath = selectors.downloadPathForGame(state, archive.game[0]);
+          const archivePath = path.join(dlPath, archive.localPath!);
+
+          const sourceChecksums: { [fileName: string]: string } = {};
+          const szip = new util.SevenZip();
+          await szip.list(archivePath, undefined, async entries => {
+            for (const entry of entries) {
+              if (entry.attr !== 'D') {
+                try {
+                  sourceChecksums[entry.name] = entry['crc'].toUpperCase();
+                } catch (err) {
+                  api.showErrorNotification!('Failed to determine checksum for file', err, {
+                    message: entry.name,
+                  });
+                }
+              }
+            }
+          });
+
+          let entries: string[] = [];
+          await util.walk(localPath, async input => {
+            entries = [].concat(entries, input);
+          }, {});
+
+          const copyInstructions = instRes.instructions.filter(instr => instr.type === 'copy');
+          const matched: Set<string> = new Set();
+          for (const file of copyInstructions) {
+            const srcCRC = sourceChecksums[file.source!];
+            let relevantEntries = entries.filter(entry => path.basename(entry) === path.basename(file.source));
+            await new Promise<void>(async (resolve, _) => {
+              for (const entry of relevantEntries) {
+                const data = await fs.readFileAsync(entry);
+                const dstCRC = crcFromBuf(data);
+                if (dstCRC === srcCRC) {
+                  log('debug', 'found matching file', { filePath: entry, srcCRC, dstCRC });
+                  matched.add(path.basename(entry));
+                }
+              }
+              return resolve();
+            });
+          }
+          if (matched.size !== copyInstructions.length) {
+            const mismatched = copyInstructions
+              .filter(instr => !matched.has(path.basename(instr.source)))
+              .map(instr => path.basename(instr.source));
+            return reject(new ReplicateHashMismatchError(mismatched));
+          }
+          return resolve();
+        } catch (err) {
+          return reject(err);
+        }
+      })
+  }), false) as Bluebird<void>;
+}

--- a/src/util/errors.ts
+++ b/src/util/errors.ts
@@ -1,0 +1,14 @@
+export class ReplicateHashMismatchError extends Error {
+  mayIgnore: boolean = false;
+  affectedFiles: string[];
+  constructor(affectedFiles: string[]) {
+    super('Replicate install mode can only work if the checksums of the installed files match those in the archive. Please try to reinstall the mod or use binary patching instead.');
+    this.name = 'ReplicateHashMismatchError';
+    this.mayIgnore = false;
+    this.affectedFiles = affectedFiles;
+  }
+
+  toString(): string {
+    return `${this.name}: ${this.message} (affected files: ${this.affectedFiles.join(', ')})`;
+  }
+}


### PR DESCRIPTION
The replicate install mode is meant to be used as a way to restructure the mod archive's folder structure, checksum differences are not carried over to the end user which is guaranteed to cause modding environment mismatches between the user and the curator.

We no longer allow curators to export mods which have local changes, using the replicate install mode.

closes nexus-mods/vortex#17368