### PR TITLE
version match default to exact only when creating collections

### DIFF
--- a/src/views/CollectionPageEdit/ModsEditPage.tsx
+++ b/src/views/CollectionPageEdit/ModsEditPage.tsx
@@ -505,8 +505,7 @@ class ModsEditPage extends ComponentEx<IProps, IModsPageState> {
 
           if (entry.rule.reference.versionMatch === '*') {
             return t('Latest');
-          } else if ((entry.rule.reference.versionMatch === undefined)
-            || (entry.rule.reference.versionMatch || '').endsWith('+prefer')) {
+          } else if ((entry.rule.reference.versionMatch || '').endsWith('+prefer')) {
             return t('Prefer exact ({{version}})', { replace: { version } });
           } else {
             return t('Exact only ({{version}})', { replace: { version } });


### PR DESCRIPTION
closes https://github.com/Nexus-Mods/Vortex/issues/18214